### PR TITLE
US Death Count ORM Model & Fetch Endpoint

### DIFF
--- a/src/crud/us_deathcounts.py
+++ b/src/crud/us_deathcounts.py
@@ -1,0 +1,14 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from src.models.us_deathcounts import USDeathCounts
+from src.dependencies.sqlalchemy_connection import sqlalchemy_engine
+
+
+def fetch_us_deathcounts():
+    engine = sqlalchemy_engine()
+    with Session(engine) as session:
+        stmt = select(USDeathCounts)
+        results = session.execute(stmt).scalars().all()
+        # Convert model instances to dicts for FastAPI serialization
+        us_deathcounts_list = [weather.model_dump() for weather in results]
+    return us_deathcounts_list

--- a/src/crud/us_deathcounts.py
+++ b/src/crud/us_deathcounts.py
@@ -10,5 +10,5 @@ def fetch_us_deathcounts():
         stmt = select(USDeathCounts)
         results = session.execute(stmt).scalars().all()
         # Convert model instances to dicts for FastAPI serialization
-        us_deathcounts_list = [weather.model_dump() for weather in results]
+        us_deathcounts_list = [death.model_dump() for death in results]
     return us_deathcounts_list

--- a/src/dependencies/sqlalchemy_connection.py
+++ b/src/dependencies/sqlalchemy_connection.py
@@ -1,0 +1,18 @@
+import os
+from sqlalchemy import create_engine
+
+
+def sqlalchemy_engine():
+    account = os.getenv("SNOWFLAKE_ACCOUNT")
+    user = os.getenv("SNOWFLAKE_USER")
+    password = os.getenv("SNOWFLAKE_PASSWORD")
+    database = os.getenv("SNOWFLAKE_DATABASE")
+    schema = os.getenv("SNOWFLAKE_SCHEMA_SILVER")
+    warehouse = os.getenv("SNOWFLAKE_WAREHOUSE")
+    role = os.getenv("SNOWFLAKE_ROLE")
+
+    engine = create_engine(
+        f"snowflake://{user}:{password}@{account}/{database}/{schema}?warehouse={warehouse}&role={role}"
+    )
+
+    return engine

--- a/src/dependencies/sqlalchemy_connection.py
+++ b/src/dependencies/sqlalchemy_connection.py
@@ -1,5 +1,8 @@
 import os
 from sqlalchemy import create_engine
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 def sqlalchemy_engine():
@@ -7,7 +10,7 @@ def sqlalchemy_engine():
     user = os.getenv("SNOWFLAKE_USER")
     password = os.getenv("SNOWFLAKE_PASSWORD")
     database = os.getenv("SNOWFLAKE_DATABASE")
-    schema = os.getenv("SNOWFLAKE_SCHEMA_SILVER")
+    schema = os.getenv("SNOWFLAKE_SCHEMA_CLEANED")
     warehouse = os.getenv("SNOWFLAKE_WAREHOUSE")
     role = os.getenv("SNOWFLAKE_ROLE")
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from src.dependencies.logger_init import setup_logging
+from src.crud.us_deathcounts import fetch_us_deathcounts
 
 app = FastAPI()
 
@@ -12,3 +13,12 @@ async def read_root():
         "message": "Welcome to the FastAPI demo! Visit /docs for API documentation and how to use this."
     }
 
+@app.get("/us-deathcounts")
+async def fetch_us_deathcounts_endpoint():
+    try:
+        data = fetch_us_deathcounts()
+        logger.info(f"Fetched {len(data)} records from CLN_US_DEATHCOUNTS.")
+        return {"data": data}
+    except Exception as e:
+        logger.error(f"Error fetching data: {e}")
+        return {"error": str(e)}

--- a/src/models/us_deathcounts.py
+++ b/src/models/us_deathcounts.py
@@ -1,0 +1,20 @@
+
+from sqlmodel import SQLModel, Field
+from typing import Optional
+from datetime import date
+
+#FIXME: Requires a primary key
+class USDeathCounts(SQLModel, table=True):
+    __tablename__ = "CLN_US_DEATHCOUNTS"
+    year: int = Field()
+    month: int = Field()
+    group: str = Field()
+    subgroup1: Optional[str] = Field()
+    subgroup2: Optional[str] = Field()
+    covid_deaths: Optional[int] = Field()
+    crude_covid_death_rate: Optional[int] = Field()
+    age_adjusted_covid_death_rate: Optional[int] = Field()
+    annualized_crude_covid_death_rate: Optional[int] = Field()
+    annualized_age_adjusted_covid_death_rate: Optional[int] = Field()
+    footnote: Optional[str] = Field()
+    LAST_UPDATED: Optional[date] = Field()

--- a/src/models/us_deathcounts.py
+++ b/src/models/us_deathcounts.py
@@ -6,6 +6,7 @@ from datetime import date
 #FIXME: Requires a primary key
 class USDeathCounts(SQLModel, table=True):
     __tablename__ = "CLN_US_DEATHCOUNTS"
+    id: int = Field(primary_key=True)
     year: int = Field()
     month: int = Field()
     group: str = Field()

--- a/src/models/us_deathcounts.py
+++ b/src/models/us_deathcounts.py
@@ -1,21 +1,21 @@
-
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, Column
+from sqlalchemy import String, Integer, Date
 from typing import Optional
 from datetime import date
 
-#FIXME: Requires a primary key
 class USDeathCounts(SQLModel, table=True):
     __tablename__ = "CLN_US_DEATHCOUNTS"
-    id: int = Field(primary_key=True)
-    year: int = Field()
-    month: int = Field()
-    group: str = Field()
-    subgroup1: Optional[str] = Field()
-    subgroup2: Optional[str] = Field()
-    covid_deaths: Optional[int] = Field()
-    crude_covid_death_rate: Optional[int] = Field()
-    age_adjusted_covid_death_rate: Optional[int] = Field()
-    annualized_crude_covid_death_rate: Optional[int] = Field()
-    annualized_age_adjusted_covid_death_rate: Optional[int] = Field()
-    footnote: Optional[str] = Field()
-    LAST_UPDATED: Optional[date] = Field()
+
+    id: int = Field(sa_column=Column("id", Integer, primary_key=True, quote=True))
+    year: int = Field(sa_column=Column("year", Integer, quote=True))
+    month: int = Field(sa_column=Column("month", Integer, quote=True))
+    group: str = Field(sa_column=Column("group", String, quote=True))
+    subgroup1: Optional[str] = Field(sa_column=Column("subgroup1", String, quote=True))
+    subgroup2: Optional[str] = Field(sa_column=Column("subgroup2", String, quote=True))
+    covid_deaths: Optional[int] = Field(sa_column=Column("covid_deaths", Integer, quote=True))
+    crude_covid_death_rate: Optional[int] = Field(sa_column=Column("crude_covid_death_rate", Integer, quote=True))
+    age_adjusted_covid_death_rate: Optional[int] = Field(sa_column=Column("age_adjusted_covid_death_rate", Integer, quote=True))
+    annualized_crude_covid_death_rate: Optional[int] = Field(sa_column=Column("annualized_crude_covid_death_rate", Integer, quote=True))
+    annualized_age_adjusted_covid_death_rate: Optional[int] = Field(sa_column=Column("annualized_age_adjusted_covid_death_rate", Integer, quote=True))
+    footnote: Optional[str] = Field(sa_column=Column("footnote", String, quote=True))
+    LAST_UPDATED: date = Field(sa_column=Column("LAST_UPDATED", Date, quote=True))


### PR DESCRIPTION
This pull request introduces a new feature to fetch and expose U.S. death counts data through a FastAPI endpoint. The changes include setting up the database connection, defining the data model, implementing the data-fetching logic, and creating the API endpoint.

### Database Integration and Data Model:

* [`src/dependencies/sqlalchemy_connection.py`](diffhunk://#diff-003d152bf450da6d0789ae67c94181f3516c123e5ecc2c3380a8116d0e2d51e4R1-R21): Added a function `sqlalchemy_engine` to establish a Snowflake database connection using environment variables.
* [`src/models/us_deathcounts.py`](diffhunk://#diff-07473247fa414bcf5b0637476241e9f8c611cb0fe571c915bea6b9cf788bf935R1-R21): Defined the `USDeathCounts` model using `SQLModel` to map to the `CLN_US_DEATHCOUNTS` table in the database.

### Data Fetching Logic:

* [`src/crud/us_deathcounts.py`](diffhunk://#diff-375f87e59236b6c9558c343f007368027438ac5f8bbac764cf40a81c55161379R1-R14): Implemented the `fetch_us_deathcounts` function to query the `CLN_US_DEATHCOUNTS` table and return the results as a list of dictionaries.

### API Endpoint:

* [`src/main.py`](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R16-R24): Added a new GET endpoint `/us-deathcounts` that uses the `fetch_us_deathcounts` function to retrieve data and return it as a JSON response. Includes error handling and logging.

These changes collectively enable the application to fetch and serve U.S. death counts data from the Snowflake database through a REST API.