### PR TITLE
Filter /databases by country, keyword, and last_updated

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -3,35 +3,28 @@ from datetime import date
 DATABASE_METADATA = {
   1: {
     "database_id": 1,
-    "database_tablename": "CLN_CA_ANTIBODY",
     "country": "Canada",
     "dataset_name": "SARS-CoV-2 antibody seroprevalence in Canadians, by age group and sex, November 2020 to April 2021",
     "description": "[Subsetted to only include national-level data] Seroprevalence of Canadians aged 1 and older with antibodies against SARS-CoV-2 (the virus that causes COVID-19), overall and by antibody type, by age group and sex.",
-    "last_updated": "2025-05-26",
-    "data": None
+    "last_updated": "2025-05-26"
   },
   2: {
     "database_id": 2,
-    "database_tablename": "CLN_CA_RAPIDTESTDEMAND",
     "country": "Canada",
     "dataset_name": "COVID-19 Rapid Test kits demand and usage",
     "description": "[Subsetted to only include national-level data] Percent of businesses that used COVID-19 Rapid Test kits to test on-site employees and percent of businesses that plan to test on-site employees in the next threee months by North American Industry Classification System (NAICS) for Canada and regions. Includes business' reason for not having plans to use COVID-19 Rapid Test Kits in the next three months and the percent of businesses that test employees less than once a week/once a week/twice a week/more than twice a week. Further includes percent of businesses that indicated COVID-19 Rapid Test kits as being essential personal protective equipment (PPE) or that expect to have shortages within the next 3 months.",
-    "last_updated": "2025-05-26",
-    "data": None
+    "last_updated": "2025-05-26"
   },
   3: {
     "database_id": 3,
-    "database_tablename": "CLN_UK_COVCASESBYDAY",
-    "country": "United Kingdom",
+    "country": "United Kingdom (UK)",
     "dataset_name": "Covid-19 Cases By Day",
     "description": "National count of new Covid-19 cases in the United Kingdom. Includes epidemiological week.",
-    "last_updated": str(date.today()),
-    "data": None
+    "last_updated": str(date.today())
   },
   4: {
     "database_id": 4,
-    "database_tablename": "CLN_US_DEATHCOUNTS",
-    "country": "United States",
+    "country": "United States of America (USA)",
     "dataset_name": "Provisional COVID-19 death counts and rates by month, jurisdiction of residence, and demographic characteristics",
     "description": """[Subsetted to only include national-level data] This file contains COVID-19 death counts and rates by month and year of death, jurisdiction of residence (U.S., HHS Region) and demographic characteristics (sex, age, race and Hispanic origin, and age/race and Hispanic origin). United States death counts and rates include the 50 states, plus the District of Columbia.
 
@@ -44,7 +37,6 @@ Death counts should not be compared across jurisdictions. Data timeliness varies
 Rates were calculated using the population estimates for 2021, which are estimated as of July 1, 2021 based on the Blended Base produced by the US Census Bureau in lieu of the April 1, 2020 decennial population count. The Blended Base consists of the blend of Vintage 2020 postcensal population estimates, 2020 Demographic Analysis Estimates, and 2020 Census PL 94-171 Redistricting File (see https://www2.census.gov/programs-surveys/popest/technical-documentation/methodology/2020-2021/methods-statement-v2021.pdf).
 
 Rate are based on deaths occurring in the specified week and are age-adjusted to the 2000 standard population using the direct method (see https://www.cdc.gov/nchs/data/nvsr/nvsr70/nvsr70-08-508.pdf). These rates differ from annual age-adjusted rates, typically presented in NCHS publications based on a full year of data and annualized weekly age-adjusted rates which have been adjusted to allow comparison with annual rates. Annualization rates presents deaths per year per 100,000 population that would be expected in a year if the observed period specific (weekly) rate prevailed for a full year.""",
-    "last_updated": str(date.today()),
-    "data": None
+    "last_updated": str(date.today())
   }
 }

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from src.dependencies.logger_init import setup_logging
 from src.crud.get_single_database import fetch_single_database
+from src.config import DATABASE_METADATA
 
 app = FastAPI()
 
@@ -17,11 +18,25 @@ async def read_root():
 async def get_all_databases(country: str = None, keyword: str = None, last_updated: int = None):
     logger.info(f"Databases endpoint accessed with query parameters: country={country}, keyword={keyword}, last_updated={last_updated}")
 
-    return {"input parameters": {
-        "country": country,
-        "keyword": keyword,
-        "last_updated": last_updated
-    }}
+    headers_filtered = DATABASE_METADATA.values()
+    logger.info(f"{len(headers_filtered)} databases selected")
+
+    try:
+        if country != None:
+            headers_filtered = [item for item in headers_filtered if country.lower() in item["country"].lower()]
+
+        if keyword != None:
+           # Allow for keyword to match where "covid 19" == "covid-19"
+           keyword_simple = keyword.lower().replace(" ", "").replace("-", "")
+           headers_filtered = [item for item in headers_filtered if keyword_simple in f'{item["country"].lower()}//{item["description"].lower()}//{item["dataset_name"].lower()}'.replace(" ","").replace("-", "")]
+        
+        logger.info(f"Returning {[item["dataset_name"] for item in headers_filtered]}")
+
+    except Exception as e:
+        logger.info(e)
+        return {"error": e}
+        
+    return {"data": headers_filtered}
 
 @app.get("/databases/{database_id}")
 async def get_single_database(database_id: int, limit: int = 20, offset: int = 0):

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,5 @@
+import re
+from datetime import datetime
 from fastapi import FastAPI
 from src.dependencies.logger_init import setup_logging
 from src.crud.get_single_database import fetch_single_database
@@ -15,10 +17,10 @@ async def read_root():
     }
 
 @app.get("/databases/")
-async def get_all_databases(country: str = None, keyword: str = None, last_updated: int = None):
+async def get_all_databases(country: str = None, keyword: str = None, last_updated: str = None):
     logger.info(f"Databases endpoint accessed with query parameters: country={country}, keyword={keyword}, last_updated={last_updated}")
 
-    headers_filtered = DATABASE_METADATA.values()
+    headers_filtered = [dataset for dataset in DATABASE_METADATA.values()]
     logger.info(f"{len(headers_filtered)} databases selected")
 
     try:
@@ -26,15 +28,39 @@ async def get_all_databases(country: str = None, keyword: str = None, last_updat
             headers_filtered = [item for item in headers_filtered if country.lower() in item["country"].lower()]
 
         if keyword != None:
-           # Allow for keyword to match where "covid 19" == "covid-19"
-           keyword_simple = keyword.lower().replace(" ", "").replace("-", "")
-           headers_filtered = [item for item in headers_filtered if keyword_simple in f'{item["country"].lower()}//{item["description"].lower()}//{item["dataset_name"].lower()}'.replace(" ","").replace("-", "")]
+            # Allow for keyword to match where "covid 19" == "covid-19"
+            keyword_simple = keyword.lower().replace(" ", "").replace("-", "")
+            headers_filtered = [item for item in headers_filtered if keyword_simple in f'{item["country"].lower()}//{item["description"].lower()}//{item["dataset_name"].lower()}'.replace(" ","").replace("-", "")]
+
+        if last_updated != None:
+            date_patterns = [
+                ('%Y', r'^\d{4}$'),
+                ('%Y-%m', r'^\d{4}-\d{2}$'),
+                ('%Y-%m-%d', r'^\d{4}-\d{2}-\d{2}$')
+            ]
+            input_format = None
+
+            for pattern in date_patterns:
+                if re.match(pattern[1], last_updated):
+                    input_format = pattern[0]
+            if input_format != None:
+                headers_filtered = [item for item in headers_filtered if datetime.strptime(item["last_updated"], "%Y-%m-%d") >= datetime.strptime(last_updated, input_format)]
+            else:
+                logger.info(f"Date input {last_updated} is not in valid format")
+
+                return {"error": "last_updated must be a date in the format YYYY-MM-DD, YYYY-MM, YYYY. Databases will return that have been updated on or since that date."}
         
         logger.info(f"Returning {[item["dataset_name"] for item in headers_filtered]}")
-
     except Exception as e:
         logger.info(e)
-        return {"error": e}
+        return {"error": f'{e}'}
+    
+    for database in headers_filtered:
+        try:
+            database["data_preview"] = fetch_single_database(database["database_id"], 0, 5)
+        except Exception as e:
+            logger.error(e)
+            raise
         
     return {"data": headers_filtered}
 


### PR DESCRIPTION
/databases endpoint returns all databases with a 5 entry data_preview (visit /databases/{database_id} for complete, paginated data)

Filter on country name, keyword, and last_updated (in format YYYY, YYYY-MM, or YYYY-MM-DD)

Some alterations to config.py